### PR TITLE
Add release-package directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ CLAUDE.md
 .claude/
 *.claude
 SPRINTS.md
+release-package/
+backend/release-package/


### PR DESCRIPTION
## Summary
- Added release-package directories to .gitignore to exclude build artifacts from version control

## Changes
- Added `release-package/` to .gitignore (root directory)
- Added `backend/release-package/` to .gitignore

## Test plan
- [x] Verified .gitignore entries are correctly formatted
- [x] Confirmed directories will be excluded from git tracking