### PR TITLE
[ACB-69] Fix invalid date display in chat messages

### DIFF
--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -72,13 +72,13 @@ const ChatWindow = () => {
           id: -1,
           ai: false,
           content: userMessage,
-          created_at: "now",
+          created_at: new Date().toISOString(),
         });
         pushMessage({
           id: -2,
           ai: true,
           content: `${companionData.name} is typing...`,
-          created_at: "",
+          created_at: new Date().toISOString(),
         })
         resolve();
       });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,6 +7,12 @@ export function cn(...inputs: ClassValue[]) {
 
 export function formatMessageDate(dateString: string): string {
   const date = new Date(dateString);
+  
+  // Validate date and provide fallback for invalid dates
+  if (isNaN(date.getTime())) {
+    return "Just now";
+  }
+  
   const now = new Date();
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const messageDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());


### PR DESCRIPTION
## Summary
- Fixed "Invalid Date, NaN @ invalid date" display issue in chat messages
- Replaced invalid date strings with proper ISO timestamps
- Added date validation with graceful fallback

## Changes
1. **ChatWindow.tsx**: Updated temporary message creation to use `new Date().toISOString()` instead of "now" and empty strings
2. **utils.ts**: Added date validation in `formatMessageDate` function that returns "Just now" for invalid dates

## Test Plan
- [x] Verified temporary messages display correct timestamps during sending
- [x] Tested with existing messages to ensure backward compatibility  
- [x] Confirmed "typing..." indicator shows appropriate timestamp
- [x] Validated edge cases (empty dates, malformed dates)
- [x] Ran linter - no errors

## JIRA Issue
[ACB-69](https://ericfisherdev.atlassian.net/browse/ACB-69)